### PR TITLE
chore: move TypeDoc config to tsconfig.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ These are the most relevant commands that you'll likely use:
 | ---- | ---- | ------------- |
 | NPM package | [`package.json`](./package.json) | [docs](https://docs.npmjs.com/cli/v9/configuring-npm/package-json), [website](https://docs.npmjs.com/) |
 | TypeScript | [`tsconfig.json`](./tsconfig.json) | [docs](https://www.typescriptlang.org/tsconfig), [website](https://www.typescriptlang.org/) |
+| TypeDoc (documentation generator) | [`tsconfig.json`](./tsconfig.json) (`typedocOptions`) | [docs](https://typedoc.org/options/configuration/), [website](https://typedoc.org/) |
 | ESLint (code formatter + linter) | [`eslint.config.js`](./eslint.config.js) | [docs](https://eslint.org/docs/latest/user-guide/configuring/), [website](https://eslint.org/) |
 | Vite (bundler) | [`vite.config.ts`](./vite.config.ts) | [docs](https://vitejs.dev/config/), [website](https://vitejs.dev/) |
 | Vitest (testing framework) | [`vitest.config.ts`](./vitest.config.ts) | [docs](https://vitest.dev/config/), [website](https://vitest.dev/) |
-| TypeDoc (documentation generator) | [`typedoc.json`](./typedoc.json) | [docs](https://typedoc.org/options/configuration/), [website](https://typedoc.org/) |
 | CodeSandbox CI | [`.codesandbox/ci.json`](./.codesandbox/ci.json) | [docs](https://codesandbox.io/docs/learn/sandboxes/ci#configuration), [website](https://codesandbox.io/) |
 | Dependabot | [`.github/dependabot.yml`](./.github/dependabot.yml) | [docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file), [website](https://github.com/dependabot) |
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,13 @@
 	"exclude": [
 		"node_modules",
 		"**/__tests__/*"
-	]
+	],
+	"typedocOptions": {
+		"entryPoints": [
+			"src/index.ts"
+		],
+		"out": "docs/typedocs",
+		"lightHighlightTheme": "github-light",
+		"darkHighlightTheme": "github-dark"
+	}
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,8 +1,0 @@
-{
-	"entryPoints": [
-		"src/index.ts"
-	],
-	"out": "docs/typedocs",
-	"lightHighlightTheme": "github-light",
-	"darkHighlightTheme": "github-dark"
-}


### PR DESCRIPTION
This is intended to reduce the number of config files in the root directory.